### PR TITLE
1.17 is hosted on a different filename

### DIFF
--- a/cloud_sql_proxy.rb
+++ b/cloud_sql_proxy.rb
@@ -1,7 +1,7 @@
 class CloudSqlProxy < Formula
   desc "The Cloud SQL Proxy for GoogleCloudPlatform"
   homepage "https://github.com/GoogleCloudPlatform/cloudsql-proxy"
-  version "1.17"
+  version "v1.17"
   url "https://github.com/GoogleCloudPlatform/cloudsql-proxy/archive/#{version}.tar.gz"
   sha256 "cd4f426f779ede8c87f0efd7f47b7fd86f59157192df37a62822dd9ff53e5113"
   head "https://github.com/GoogleCloudPlatform/cloudsql-proxy.git"

--- a/cloud_sql_proxy.rb
+++ b/cloud_sql_proxy.rb
@@ -3,7 +3,7 @@ class CloudSqlProxy < Formula
   homepage "https://github.com/GoogleCloudPlatform/cloudsql-proxy"
   version "v1.17"
   url "https://github.com/GoogleCloudPlatform/cloudsql-proxy/archive/#{version}.tar.gz"
-  sha256 "cd4f426f779ede8c87f0efd7f47b7fd86f59157192df37a62822dd9ff53e5113"
+  sha256 "241f5b7a2118bfd1a305b249e95f67b4bbedb3ee62783b492d3d9e445d7c12e1"
   head "https://github.com/GoogleCloudPlatform/cloudsql-proxy.git"
   
   depends_on "go" => :build


### PR DESCRIPTION
For some reason 1.17 has a `v` prefix to the actual assets.