### PR TITLE
update to V1240

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 
 in your terminal:
 ```
-brew tap tclass/cloud_sql_proxy
+brew tap gen16k/cloud_sql_proxy
 brew install cloud_sql_proxy
 ```

--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 
 in your terminal:
 ```
-brew tap gen16k/cloud_sql_proxy
+brew tap tclass/cloud_sql_proxy
 brew install cloud_sql_proxy
 ```

--- a/cloud_sql_proxy.rb
+++ b/cloud_sql_proxy.rb
@@ -1,7 +1,7 @@
 class CloudSqlProxy < Formula
   desc "The Cloud SQL Proxy for GoogleCloudPlatform"
   homepage "https://github.com/GoogleCloudPlatform/cloudsql-proxy"
-  version "1.20.2"
+  version "1.24.0"
   url "https://github.com/GoogleCloudPlatform/cloudsql-proxy/archive/v#{version}.tar.gz"
   sha256 "a2dca081982b155ba5bf2604b438321b9d3bc2e9502e944e43ee988359cb7de6"
   head "https://github.com/GoogleCloudPlatform/cloudsql-proxy.git"

--- a/cloud_sql_proxy.rb
+++ b/cloud_sql_proxy.rb
@@ -3,7 +3,7 @@ class CloudSqlProxy < Formula
   homepage "https://github.com/GoogleCloudPlatform/cloudsql-proxy"
   version "1.24.0"
   url "https://github.com/GoogleCloudPlatform/cloudsql-proxy/archive/v#{version}.tar.gz"
-  sha256 "a2dca081982b155ba5bf2604b438321b9d3bc2e9502e944e43ee988359cb7de6"
+  sha256 "fd0dd769d48577e74522a8206032ef5ae80c34d5273ee7ea1d707a4e3dffec0c"
   head "https://github.com/GoogleCloudPlatform/cloudsql-proxy.git"
   
   depends_on "go" => :build

--- a/cloud_sql_proxy.rb
+++ b/cloud_sql_proxy.rb
@@ -3,7 +3,7 @@ class CloudSqlProxy < Formula
   homepage "https://github.com/GoogleCloudPlatform/cloudsql-proxy"
   version "1.24.0"
   url "https://github.com/GoogleCloudPlatform/cloudsql-proxy/archive/v#{version}.tar.gz"
-  sha256 "fd0dd769d48577e74522a8206032ef5ae80c34d5273ee7ea1d707a4e3dffec0c"
+  sha256 "7006685f0bb23c1dd519da139ea341c34bc294e28924d15302112f93823cf5bb"
   head "https://github.com/GoogleCloudPlatform/cloudsql-proxy.git"
   
   depends_on "go" => :build


### PR DESCRIPTION
I changed version number & sha256 value to update to v1.24.0 (the current newest version)

It is tested on my forked repo using linuxbrew. (https://github.com/gen16k/homebrew-cloud_sql_proxy?organization=gen16k&organization=gen16k)

That result is shown below. It seems that this is working fine.

```
$ brew install cloud_sql_proxy
Updating Homebrew...
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/core).
==> New Formulae
libaec                                                             ots
==> Updated Formulae
Updated 325 formulae.

==> Installing cloud_sql_proxy from gen16k/cloud_sql_proxy
==> Downloading https://github.com/GoogleCloudPlatform/cloudsql-proxy/archive/v1.24.0.tar.gz
Already downloaded: /home/gen16k/.cache/Homebrew/downloads/94c371c74f68551c0697e16ff0ac703f31df1baa0cd5c811da9f89efc61289e5--cloudsql-proxy-1.24.0.tar.gz
==> go build -o /home/linuxbrew/.linuxbrew/Cellar/cloud_sql_proxy/1.24.0/bin/cloud_sql_proxy ./cmd/cloud_sql_proxy
🍺  /home/linuxbrew/.linuxbrew/Cellar/cloud_sql_proxy/1.24.0: 6 files, 15.2MB, built in 2 seconds
```

I request @tclass  to review it and merge with squashing my commits because my git history is little cluttered.
