### PR TITLE
Add service for `brew service start cloud_sql_proxy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,10 @@ in your terminal:
 brew tap tclass/cloud_sql_proxy
 brew install cloud_sql_proxy
 ```
+
+### Service
+To start the `cloud_sql_proxy` service, type
+```
+brew services start cloud_sql_proxy
+```
+It is configured to serve from `/tmp/cloud_sql_proxy`.

--- a/cloud_sql_proxy.rb
+++ b/cloud_sql_proxy.rb
@@ -12,6 +12,11 @@ class CloudSqlProxy < Formula
     system "go", "build", "-o", bin/"cloud_sql_proxy", "./cmd/cloud_sql_proxy"
   end
 
+  service do
+    run [opt_bin/"cloud_sql_proxy", "-dir=/tmp/cloudsql"]
+    keep_alive true
+  end
+
   test do
     system "cloud_sql_proxy -version"
   end


### PR DESCRIPTION
This adds a section to run `cloud_sql_proxy` as a service, through:

```
brew service start cloud_sql_proxy
```

I've been using this locally.