### PR TITLE
fix build path

### DIFF
--- a/cloud_sql_proxy.rb
+++ b/cloud_sql_proxy.rb
@@ -5,11 +5,11 @@ class CloudSqlProxy < Formula
   url "https://github.com/GoogleCloudPlatform/cloud-sql-proxy/archive/refs/tags/v#{version}.tar.gz"
   sha256 "375e577e993e72f8c35d43e2b0672862f3bb10c1ca49fcc7c1f98b9e42fb7261"
   head "https://github.com/GoogleCloudPlatform/cloud-sql-proxy.git"
-  
+
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-o", bin/"cloud_sql_proxy", "./cmd/cloud_sql_proxy"
+    system "go", "build", "-o", bin/"cloud_sql_proxy", "."
   end
 
   service do


### PR DESCRIPTION
Looks like for v2 the binary has moved to the root of the repository.

With the current brew formula the brew fails as follows:

```
==> Upgrading tclass/cloud_sql_proxy/cloud_sql_proxy
  1.32.0 -> 2.0.0 

==> go build -o /opt/homebrew/Cellar/cloud_sql_proxy/2.0.0/bin/cloud_sql_proxy ./cmd/cloud_sql_proxy
Last 15 lines from /Users/filip/Library/Logs/Homebrew/cloud_sql_proxy/01.go:
2023-03-04 00:51:19 +0000

go
build
-o
/opt/homebrew/Cellar/cloud_sql_proxy/2.0.0/bin/cloud_sql_proxy
./cmd/cloud_sql_proxy

stat /private/tmp/cloud_sql_proxy-20230303-87022-19wecxq/cloud-sql-proxy-2.0.0/cmd/cloud_sql_proxy: directory not found

If reporting this issue please do so at (not Homebrew/brew or Homebrew/homebrew-core):
  https://github.com/tclass/homebrew-cloud_sql_proxy/issues
```